### PR TITLE
Centralize configuration and add marshmallow schemas

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
+APP_PORT=5001
+FLASK_SECRET=dev
+CORS_ORIGINS=http://localhost:5173,http://localhost:3000
+
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 GOOGLE_REDIRECT_URI=http://localhost:5000/auth/google/callback
@@ -14,4 +18,5 @@ ALLOWED_REDIRECTS=http://localhost:5173/callback,http://localhost:3000/callback
 APP_BASE_URL=http://localhost:5000
 DATABASE_URL=postgresql+psycopg://user:password@localhost:5432/meetinity
 REDIS_URL=redis://localhost:6379/0
+REDIS_CACHE_TTL=300
 SQLALCHEMY_ECHO=false

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ The User Service is a comprehensive authentication and user management microserv
 - **Requests**: HTTP client for OAuth provider communication
 - **Python-dotenv**: Environment variable management
 - **Flask-CORS**: Cross-Origin Resource Sharing support
+- **SQLAlchemy**: ORM used for persistence and migrations
+- **Marshmallow**: Declarative serialization layer for API responses
 
 ## Project Status
 
@@ -36,6 +38,8 @@ The User Service is a comprehensive authentication and user management microserv
 ## Configuration
 
 - `CORS_ORIGINS`: comma-separated list of allowed origins for CORS. Defaults to `*`.
+- `APP_PORT`: TCP port used when running `python src/main.py`. Defaults to `5001`.
+- `FLASK_SECRET`: secret key used for Flask session signing.
 - `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` / `GOOGLE_REDIRECT_URI`: Google OAuth credentials and callback URL.
 - `LINKEDIN_CLIENT_ID` / `LINKEDIN_CLIENT_SECRET` / `LINKEDIN_REDIRECT_URI`: LinkedIn OAuth credentials and callback URL.
 - `DATABASE_URL`: SQLAlchemy database URL (e.g. `postgresql+psycopg://user:pass@localhost:5432/meetinity`).
@@ -52,6 +56,7 @@ The User Service is a comprehensive authentication and user management microserv
 pip install -r requirements.txt
 alembic upgrade head  # apply DB migrations
 flake8 src tests
+pytest
 pytest --cov=src --cov=tests --cov-report=term-missing --cov-fail-under=90
 ```
 
@@ -59,6 +64,13 @@ pytest --cov=src --cov=tests --cov-report=term-missing --cov-fail-under=90
 
 ```bash
 python src/main.py
+```
+
+or using Flask's CLI:
+
+```bash
+export FLASK_APP=src.main:app
+flask run --port ${APP_PORT:-5001}
 ```
 
 ## Database & Cache Provisioning

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
 Authlib==1.3.0
 Flask==3.0.0
 Flask-CORS==4.0.0
+marshmallow==3.20.1
 PyJWT==2.8.0
-SQLAlchemy==2.0.23
+SQLAlchemy==2.0.25
 alembic==1.12.1
 psycopg[binary]==3.1.12
 redis==5.0.1

--- a/src/db/session.py
+++ b/src/db/session.py
@@ -8,7 +8,12 @@ from typing import Iterator
 from sqlalchemy import create_engine
 from sqlalchemy.engine import Engine
 from sqlalchemy.engine.url import make_url
-from sqlalchemy.orm import DeclarativeBase, Session, close_all_sessions, sessionmaker
+from sqlalchemy.orm import (
+    DeclarativeBase,
+    Session,
+    close_all_sessions,
+    sessionmaker,
+)
 from sqlalchemy.pool import StaticPool
 
 from src.config import get_config

--- a/src/main.py
+++ b/src/main.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 """Main application file for the User Service."""
 
-import os
 from datetime import datetime, timezone
 
 from flask import Flask, jsonify
@@ -11,6 +10,10 @@ from werkzeug.exceptions import HTTPException
 from src.auth.oauth import init_oauth
 from src.config import Config, get_config
 from src.routes.auth import auth_bp
+from src.schemas.user import UserSchema
+
+
+user_list_schema = UserSchema(many=True)
 
 
 def create_app(config: Config | None = None) -> Flask:
@@ -57,7 +60,7 @@ def create_app(config: Config | None = None) -> Flask:
     @app.route("/users")
     def users():
         """Placeholder endpoint returning an empty list of users."""
-        return jsonify({"users": []})
+        return jsonify({"users": user_list_schema.dump([])})
 
     app.register_blueprint(auth_bp)
 
@@ -68,5 +71,4 @@ app = create_app()
 
 
 if __name__ == "__main__":
-    port = int(os.getenv("PORT", "5001"))
-    app.run(debug=True, port=port)
+    app.run(debug=True, port=app.config["APP_CONFIG"].app_port)

--- a/src/routes/auth.py
+++ b/src/routes/auth.py
@@ -17,8 +17,10 @@ from src.auth.oauth import (
 )
 from src.db.session import session_scope
 from src.models.user_repository import UserRepository
+from src.schemas.user import UserSchema
 
 auth_bp = Blueprint("auth", __name__, url_prefix="/auth")
+user_schema = UserSchema()
 
 ALLOWED_REDIRECTS = {
     value.strip()
@@ -214,37 +216,4 @@ def _profile_cache_key(user_id: int) -> str:
 def _serialize_user(user) -> Dict[str, Any]:
     """Serialize a user object for JSON responses/caching."""
 
-    def _dt_to_iso(dt: datetime | None) -> str | None:
-        return dt.isoformat() if dt else None
-
-    return {
-        "id": user.id,
-        "email": user.email,
-        "name": user.name,
-        "photo_url": user.photo_url,
-        "title": user.title,
-        "company": user.company,
-        "location": user.location,
-        "provider": user.provider,
-        "provider_user_id": user.provider_user_id,
-        "last_login": _dt_to_iso(user.last_login),
-        "last_active_at": _dt_to_iso(user.last_active_at),
-        "bio": user.bio,
-        "timezone": user.timezone,
-        "is_active": user.is_active,
-        "preferences": {
-            pref.key: pref.value for pref in getattr(user, "preferences", [])
-        },
-        "social_accounts": [
-            {
-                "provider": account.provider,
-                "provider_user_id": account.provider_user_id,
-                "display_name": account.display_name,
-                "profile_url": account.profile_url,
-                "last_connected_at": _dt_to_iso(
-                    account.last_connected_at
-                ),
-            }
-            for account in getattr(user, "social_accounts", [])
-        ],
-    }
+    return user_schema.dump(user)

--- a/src/schemas/__init__.py
+++ b/src/schemas/__init__.py
@@ -1,0 +1,5 @@
+"""Marshmallow schemas exposed by the service."""
+
+from .user import UserSchema
+
+__all__ = ["UserSchema"]

--- a/src/schemas/user.py
+++ b/src/schemas/user.py
@@ -1,0 +1,64 @@
+"""User-related Marshmallow schemas."""
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+from marshmallow import Schema, fields, post_dump
+
+
+class UserSocialAccountSchema(Schema):
+    """Schema for serializing linked social accounts."""
+
+    provider = fields.String(required=True)
+    provider_user_id = fields.String(allow_none=True)
+    display_name = fields.String(allow_none=True)
+    profile_url = fields.String(allow_none=True)
+    last_connected_at = fields.DateTime(allow_none=True)
+
+
+class UserSchema(Schema):
+    """Schema for serializing ``User`` ORM instances."""
+
+    id = fields.Integer(required=True)
+    email = fields.Email(required=True)
+    name = fields.String(allow_none=True)
+    photo_url = fields.String(allow_none=True)
+    title = fields.String(allow_none=True)
+    company = fields.String(allow_none=True)
+    location = fields.String(allow_none=True)
+    provider = fields.String(allow_none=True)
+    provider_user_id = fields.String(allow_none=True)
+    last_login = fields.DateTime(allow_none=True)
+    last_active_at = fields.DateTime(allow_none=True)
+    bio = fields.String(allow_none=True)
+    timezone = fields.String(allow_none=True)
+    is_active = fields.Boolean()
+    preferences = fields.Method("_dump_preferences")
+    social_accounts = fields.List(
+        fields.Nested(UserSocialAccountSchema),
+        dump_default=list,
+    )
+
+    @staticmethod
+    def _dump_preferences(obj: Any) -> dict[str, Any]:
+        preferences: Iterable[Any] | None = getattr(
+            obj,
+            "preferences",
+            None,
+        )
+        if not preferences:
+            return {}
+        return {
+            pref.key: pref.value
+            for pref in preferences
+        }
+
+    @post_dump
+    def ensure_defaults(
+        self,
+        data: dict[str, Any],
+        **_: Any,
+    ) -> dict[str, Any]:
+        data.setdefault("preferences", {})
+        data.setdefault("social_accounts", [])
+        return data


### PR DESCRIPTION
## Summary
- extend the shared Config object to cover app port, JWT settings, and CORS and use it throughout the app
- add Marshmallow schemas for user serialization and update routes/tests to exercise configurable CORS behaviour
- document the new environment variables and dependencies across README, requirements, and .env.example

## Testing
- flake8 src tests
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d967a529448332aa5b4580621bd7ae