### PR TITLE
Implement user profile management endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,5 @@ DATABASE_URL=postgresql+psycopg://user:password@localhost:5432/meetinity
 REDIS_URL=redis://localhost:6379/0
 REDIS_CACHE_TTL=300
 SQLALCHEMY_ECHO=false
+UPLOAD_FOLDER=
+UPLOAD_URL_PREFIX=/uploads

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @decarvalhoe

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ The User Service is a comprehensive authentication and user management microserv
 - `REDIS_CACHE_TTL`: cache expiration (seconds) for Redis entries. Defaults to `300`.
 - `ALLOWED_REDIRECTS`: optional comma-separated list of additional redirect URIs for OAuth flows.
 - `JWT_SECRET` (`JWT_ALGO`, `JWT_TTL_MIN`): configuration for signing JSON Web Tokens.
+- `UPLOAD_FOLDER`: directory used to persist uploaded profile photos. Defaults to `instance/uploads`.
+- `UPLOAD_URL_PREFIX`: URL prefix returned for stored profile photos. Defaults to `/uploads`.
 - All timestamps are returned in ISO 8601 format with UTC timezone.
 
 ## Development
@@ -105,6 +107,12 @@ export REDIS_URL="redis://localhost:6379/0"
 - `GET /auth/<provider>/callback?code=..&state=..` → `{ "token": "<jwt>", "user": {...} }`
 - `POST /auth/verify` → `{ "valid": true, "sub": "<user_id>", "exp": 123 }`
 - `GET /auth/profile` (Bearer token) → `{ "user": {...} }`
+- `GET /users` → `{ "items": [User], "page": 1, "per_page": 20, "total": 0 }` with filters `industry`, `location`, `min_experience`, `max_experience`, `skills` and `sort`.
+- `GET /users/<id>` → `{ "user": User }`
+- `PUT /users/<id>` → `{ "user": User }` (update profile fields, skills, interests, status).
+- `DELETE /users/<id>` → `204 No Content`.
+- `POST /users/<id>/photo` → `{ "photo_url": "/uploads/...", "user_id": <id> }` (multipart form field `photo`).
+- `GET /users/search?q=...` → `{ "items": [...], "total": N, "query": "..." }` with pagination & filters.
 - `GET /health`
 
 ## Architecture

--- a/alembic/versions/202502130001_add_profile_fields.py
+++ b/alembic/versions/202502130001_add_profile_fields.py
@@ -1,0 +1,34 @@
+"""add extended profile fields"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "202502130001"
+down_revision = "202311300001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("users", sa.Column("industry", sa.String(length=255)))
+    op.add_column("users", sa.Column("linkedin_url", sa.String(length=512)))
+    op.add_column("users", sa.Column("experience_years", sa.Integer()))
+    op.add_column("users", sa.Column("skills", sa.Text()))
+    op.add_column("users", sa.Column("interests", sa.Text()))
+    op.create_index(
+        "ix_users_industry_location",
+        "users",
+        ["industry", "location"],
+    )
+    op.create_index("ix_users_created_at", "users", ["created_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_users_created_at", table_name="users")
+    op.drop_index("ix_users_industry_location", table_name="users")
+    op.drop_column("users", "interests")
+    op.drop_column("users", "skills")
+    op.drop_column("users", "experience_years")
+    op.drop_column("users", "linkedin_url")
+    op.drop_column("users", "industry")

--- a/src/models/user.py
+++ b/src/models/user.py
@@ -8,6 +8,7 @@ from sqlalchemy import (
     Boolean,
     DateTime,
     ForeignKey,
+    Index,
     Integer,
     String,
     Text,
@@ -23,6 +24,10 @@ class User(Base):
     """Primary user record."""
 
     __tablename__ = "users"
+    __table_args__ = (
+        Index("ix_users_industry_location", "industry", "location"),
+        Index("ix_users_created_at", "created_at"),
+    )
 
     id: Mapped[int] = mapped_column(
         Integer,
@@ -37,6 +42,9 @@ class User(Base):
     title: Mapped[str | None] = mapped_column(String(255))
     company: Mapped[str | None] = mapped_column(String(255))
     location: Mapped[str | None] = mapped_column(String(255))
+    industry: Mapped[str | None] = mapped_column(String(255))
+    linkedin_url: Mapped[str | None] = mapped_column(String(512))
+    experience_years: Mapped[int | None] = mapped_column(Integer())
     provider: Mapped[str | None] = mapped_column(String(50))
     provider_user_id: Mapped[str | None] = mapped_column(
         String(255), index=True
@@ -54,6 +62,8 @@ class User(Base):
         server_default="0",
     )
     bio: Mapped[str | None] = mapped_column(Text())
+    skills: Mapped[str | None] = mapped_column(Text())
+    interests: Mapped[str | None] = mapped_column(Text())
     timezone: Mapped[str | None] = mapped_column(String(64))
     is_active: Mapped[bool] = mapped_column(
         Boolean,

--- a/src/models/user_repository.py
+++ b/src/models/user_repository.py
@@ -3,12 +3,22 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Optional
+from typing import Iterable, Optional, Sequence, Tuple
 
-from sqlalchemy import select
+from sqlalchemy import func, or_, select
 from sqlalchemy.orm import Session
 
 from src.models.user import User, UserPreference, UserSocialAccount
+from src.utils.lists import encode_string_list
+
+
+SORT_FIELDS = {
+    "created_at": User.created_at,
+    "updated_at": User.updated_at,
+    "last_login": User.last_login,
+    "experience_years": User.experience_years,
+    "name": User.name,
+}
 
 
 class UserRepository:
@@ -84,6 +94,132 @@ class UserRepository:
 
         return user
 
+    def create_user(
+        self,
+        *,
+        email: str,
+        name: Optional[str] = None,
+        title: Optional[str] = None,
+        company: Optional[str] = None,
+        location: Optional[str] = None,
+        industry: Optional[str] = None,
+        linkedin_url: Optional[str] = None,
+        experience_years: Optional[int] = None,
+        bio: Optional[str] = None,
+        skills: Iterable[str] | None = None,
+        interests: Iterable[str] | None = None,
+        timezone: Optional[str] = None,
+        is_active: bool = True,
+    ) -> User:
+        """Create a new user record."""
+
+        normalized_email = self._normalize_email(email)
+        self._validate_email(normalized_email)
+
+        user = User(
+            email=normalized_email,
+            name=name,
+            title=title,
+            company=company,
+            location=location,
+            industry=industry,
+            linkedin_url=linkedin_url,
+            experience_years=experience_years,
+            bio=bio,
+            timezone=timezone,
+            skills=encode_string_list(skills),
+            interests=encode_string_list(interests),
+            is_active=is_active,
+        )
+        self.session.add(user)
+        self.session.flush()
+        return user
+
+    def update_user(
+        self,
+        user: User,
+        data: dict[str, object],
+    ) -> User:
+        """Update user attributes from a payload."""
+
+        mapping = {
+            "name": "name",
+            "title": "title",
+            "company": "company",
+            "location": "location",
+            "industry": "industry",
+            "linkedin_url": "linkedin_url",
+            "experience_years": "experience_years",
+            "bio": "bio",
+            "timezone": "timezone",
+            "is_active": "is_active",
+        }
+        for field, attr in mapping.items():
+            if field in data:
+                setattr(user, attr, data[field])
+
+        if "skills" in data:
+            user.skills = encode_string_list(data.get("skills"))
+        if "interests" in data:
+            user.interests = encode_string_list(data.get("interests"))
+
+        self.session.flush()
+        return user
+
+    def delete_user(self, user: User) -> None:
+        """Remove a user from the database."""
+
+        self.session.delete(user)
+        self.session.flush()
+
+    def set_photo_url(self, user: User, photo_url: str) -> User:
+        """Persist a user's photo URL."""
+
+        user.photo_url = photo_url
+        self.session.flush()
+        return user
+
+    def list_users(
+        self,
+        *,
+        page: int,
+        per_page: int,
+        sort: Tuple[str, str],
+        filters: dict[str, object],
+    ) -> Tuple[list[User], int]:
+        """Return paginated users matching filters."""
+
+        stmt = select(User)
+        stmt = stmt.where(User.is_active.is_(True))
+        stmt = self._apply_filters(stmt, filters)
+        return self._paginate(stmt, page, per_page, sort)
+
+    def search_users(
+        self,
+        *,
+        query: str,
+        page: int,
+        per_page: int,
+        sort: Tuple[str, str],
+        filters: dict[str, object],
+    ) -> Tuple[list[User], int]:
+        """Search users by free-text query and filters."""
+
+        stmt = select(User).where(User.is_active.is_(True))
+        stmt = self._apply_filters(stmt, filters)
+        pattern = f"%{query.lower()}%"
+        stmt = stmt.where(
+            or_(
+                func.lower(User.name).like(pattern),
+                func.lower(User.title).like(pattern),
+                func.lower(User.company).like(pattern),
+                func.lower(User.bio).like(pattern),
+                func.lower(func.coalesce(User.skills, "")).like(pattern),
+                func.lower(func.coalesce(User.interests, "")).like(pattern),
+            )
+        )
+        return self._paginate(stmt, page, per_page, sort)
+
     def set_preferences(
         self,
         user: User,
@@ -145,3 +281,43 @@ class UserRepository:
         match.display_name = display_name
         match.profile_url = profile_url
         match.last_connected_at = connected_at
+
+    def _apply_filters(self, stmt, filters: dict[str, object]):
+        if industry := filters.get("industry"):
+            stmt = stmt.where(User.industry == industry)
+        if location := filters.get("location"):
+            stmt = stmt.where(User.location == location)
+        if (min_exp := filters.get("min_experience")) is not None:
+            stmt = stmt.where(User.experience_years >= int(min_exp))
+        if (max_exp := filters.get("max_experience")) is not None:
+            stmt = stmt.where(User.experience_years <= int(max_exp))
+        skills = filters.get("skills")
+        if isinstance(skills, Sequence):
+            for skill in skills:
+                stmt = stmt.where(User.skills.contains(f'"{skill}"'))
+        return stmt
+
+    def _paginate(
+        self,
+        stmt,
+        page: int,
+        per_page: int,
+        sort: Tuple[str, str],
+    ) -> Tuple[list[User], int]:
+        sort_field, direction = sort
+        column = SORT_FIELDS.get(sort_field, User.created_at)
+        order_clause = column.desc() if direction == "desc" else column.asc()
+
+        count_stmt = select(func.count()).select_from(stmt.subquery())
+        total = self.session.execute(count_stmt).scalar_one()
+        if total == 0:
+            return [], 0
+
+        offset = (page - 1) * per_page
+        result_stmt = (
+            stmt.order_by(order_clause, User.id.asc())
+            .offset(offset)
+            .limit(per_page)
+        )
+        records = self.session.execute(result_stmt).scalars().unique().all()
+        return records, total

--- a/src/routes/helpers.py
+++ b/src/routes/helpers.py
@@ -1,0 +1,24 @@
+"""Shared route utilities."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from flask import jsonify
+
+
+def error_response(
+    status_code: int,
+    message: str,
+    details: dict[str, Any] | None = None,
+):
+    """Return a standardized JSON error response."""
+
+    payload = {
+        "error": {
+            "code": status_code,
+            "message": message,
+            "details": details or {},
+        }
+    }
+    return jsonify(payload), status_code

--- a/src/routes/users.py
+++ b/src/routes/users.py
@@ -1,0 +1,247 @@
+"""User profile CRUD and search endpoints."""
+
+from __future__ import annotations
+
+from typing import Mapping, Tuple
+
+from flask import Blueprint, current_app, jsonify, request
+from marshmallow import ValidationError
+
+from src.db.session import session_scope
+from src.models.user_repository import UserRepository
+from src.routes.helpers import error_response
+from src.schemas.user import UserSchema, UserUpdateSchema
+from src.services.uploads import UploadError, save_user_photo
+from src.utils.lists import normalize_string_list
+
+users_bp = Blueprint("users", __name__, url_prefix="/users")
+
+user_schema = UserSchema()
+users_schema = UserSchema(many=True)
+update_schema = UserUpdateSchema()
+
+DEFAULT_SORT = ("created_at", "desc")
+ALLOWED_SORT_FIELDS = {
+    "created_at",
+    "updated_at",
+    "last_login",
+    "experience_years",
+    "name",
+}
+
+
+@users_bp.get("")
+def list_users():
+    """Return paginated users with optional filters."""
+
+    try:
+        page, per_page, sort, filters = _parse_listing_args(request.args)
+    except ValueError as exc:
+        return error_response(400, str(exc))
+
+    with session_scope() as session:
+        repo = UserRepository(session)
+        items, total = repo.list_users(
+            page=page,
+            per_page=per_page,
+            sort=sort,
+            filters=filters,
+        )
+    return jsonify(
+        {
+            "items": users_schema.dump(items),
+            "page": page,
+            "per_page": per_page,
+            "total": total,
+        }
+    )
+
+
+@users_bp.get("/<int:user_id>")
+def get_user(user_id: int):
+    """Return a single user profile."""
+
+    with session_scope() as session:
+        repo = UserRepository(session)
+        user = repo.get(user_id)
+        if user is None:
+            return error_response(404, "user not found")
+        return jsonify({"user": user_schema.dump(user)})
+
+
+@users_bp.put("/<int:user_id>")
+def update_user(user_id: int):
+    """Update a user profile."""
+
+    payload = request.get_json(silent=True)
+    if payload is None:
+        return error_response(400, "missing request body")
+    try:
+        data = update_schema.load(payload)
+    except ValidationError as exc:
+        return error_response(422, "invalid payload", exc.messages)
+
+    with session_scope() as session:
+        repo = UserRepository(session)
+        user = repo.get(user_id)
+        if user is None:
+            return error_response(404, "user not found")
+        updated = repo.update_user(user, data)
+        return jsonify({"user": user_schema.dump(updated)})
+
+
+@users_bp.delete("/<int:user_id>")
+def delete_user(user_id: int):
+    """Delete a user profile."""
+
+    with session_scope() as session:
+        repo = UserRepository(session)
+        user = repo.get(user_id)
+        if user is None:
+            return error_response(404, "user not found")
+        repo.delete_user(user)
+    return "", 204
+
+
+@users_bp.post("/<int:user_id>/photo")
+def upload_photo(user_id: int):
+    """Upload and associate a profile photo."""
+
+    file = request.files.get("photo")
+    if file is None:
+        return error_response(400, "photo file required")
+
+    upload_folder = current_app.config.get("UPLOAD_FOLDER")
+    if not upload_folder:
+        return error_response(500, "upload folder not configured")
+    url_prefix = current_app.config.get(
+        "UPLOAD_URL_PREFIX",
+        "/uploads",
+    )
+
+    with session_scope() as session:
+        repo = UserRepository(session)
+        user = repo.get(user_id)
+        if user is None:
+            return error_response(404, "user not found")
+        try:
+            photo_url = save_user_photo(
+                file,
+                user_id=user.id,
+                upload_folder=upload_folder,
+                url_prefix=url_prefix,
+            )
+        except UploadError as exc:
+            return error_response(422, str(exc))
+        repo.set_photo_url(user, photo_url)
+        return jsonify({"photo_url": photo_url, "user_id": user.id}), 201
+
+
+@users_bp.get("/search")
+def search_users():
+    """Search users by free text with optional filters."""
+
+    query = (request.args.get("q") or "").strip()
+    if not query:
+        return error_response(400, "missing search query")
+
+    try:
+        page, per_page, sort, filters = _parse_listing_args(request.args)
+    except ValueError as exc:
+        return error_response(400, str(exc))
+
+    with session_scope() as session:
+        repo = UserRepository(session)
+        items, total = repo.search_users(
+            query=query,
+            page=page,
+            per_page=per_page,
+            sort=sort,
+            filters=filters,
+        )
+    return jsonify(
+        {
+            "items": users_schema.dump(items),
+            "page": page,
+            "per_page": per_page,
+            "total": total,
+            "query": query,
+        }
+    )
+
+
+def _parse_listing_args(
+    args: Mapping[str, str],
+) -> Tuple[int, int, Tuple[str, str], dict[str, object]]:
+    """Parse pagination, sorting, and filter arguments."""
+
+    page = _parse_int(args.get("page"), default=1, min_value=1)
+    per_page = _parse_int(
+        args.get("per_page"),
+        default=20,
+        min_value=1,
+        max_value=100,
+    )
+    sort = _parse_sort(args.get("sort"))
+
+    filters: dict[str, object] = {}
+    for key in ("industry", "location"):
+        value = (args.get(key) or "").strip()
+        if value:
+            filters[key] = value
+
+    min_exp = _parse_int(args.get("min_experience"), default=None, min_value=0)
+    max_exp = _parse_int(args.get("max_experience"), default=None, min_value=0)
+    if min_exp is not None:
+        filters["min_experience"] = min_exp
+    if max_exp is not None:
+        filters["max_experience"] = max_exp
+    if (
+        min_exp is not None
+        and max_exp is not None
+        and max_exp < min_exp
+    ):
+        raise ValueError(
+            "max_experience must be greater than or equal to min_experience"
+        )
+
+    skills_raw = args.get("skills")
+    if skills_raw:
+        skills = normalize_string_list(skills_raw.split(","))
+        if skills:
+            filters["skills"] = skills
+
+    return page, per_page, sort, filters
+
+
+def _parse_int(
+    value: str | None,
+    *,
+    default: int | None,
+    min_value: int | None = None,
+    max_value: int | None = None,
+) -> int | None:
+    if value in (None, ""):
+        return default
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"invalid integer: {value}") from exc
+    if min_value is not None and parsed < min_value:
+        raise ValueError(f"value must be >= {min_value}")
+    if max_value is not None and parsed > max_value:
+        raise ValueError(f"value must be <= {max_value}")
+    return parsed
+
+
+def _parse_sort(sort_value: str | None) -> Tuple[str, str]:
+    raw = (sort_value or "").strip() or "created_at:desc"
+    field, _, direction = raw.partition(":")
+    field = field or DEFAULT_SORT[0]
+    direction = direction or DEFAULT_SORT[1]
+    direction = direction.lower()
+    if field not in ALLOWED_SORT_FIELDS:
+        raise ValueError("invalid sort field")
+    if direction not in {"asc", "desc"}:
+        raise ValueError("invalid sort direction")
+    return field, direction

--- a/src/schemas/user.py
+++ b/src/schemas/user.py
@@ -3,7 +3,18 @@ from __future__ import annotations
 
 from typing import Any, Iterable
 
-from marshmallow import Schema, fields, post_dump
+from marshmallow import (
+    Schema,
+    ValidationError,
+    fields,
+    post_dump,
+    post_load,
+    pre_load,
+    validates_schema,
+)
+from marshmallow.validate import Length, Range, URL
+
+from src.utils.lists import decode_string_list, normalize_string_list
 
 
 class UserSocialAccountSchema(Schema):
@@ -26,12 +37,17 @@ class UserSchema(Schema):
     title = fields.String(allow_none=True)
     company = fields.String(allow_none=True)
     location = fields.String(allow_none=True)
+    industry = fields.String(allow_none=True)
+    linkedin_url = fields.String(allow_none=True)
+    experience_years = fields.Integer(allow_none=True)
     provider = fields.String(allow_none=True)
     provider_user_id = fields.String(allow_none=True)
     last_login = fields.DateTime(allow_none=True)
     last_active_at = fields.DateTime(allow_none=True)
     bio = fields.String(allow_none=True)
     timezone = fields.String(allow_none=True)
+    skills = fields.Method("_dump_skills")
+    interests = fields.Method("_dump_interests")
     is_active = fields.Boolean()
     preferences = fields.Method("_dump_preferences")
     social_accounts = fields.List(
@@ -61,4 +77,65 @@ class UserSchema(Schema):
     ) -> dict[str, Any]:
         data.setdefault("preferences", {})
         data.setdefault("social_accounts", [])
+        data.setdefault("skills", [])
+        data.setdefault("interests", [])
         return data
+
+    @staticmethod
+    def _dump_skills(obj: Any) -> list[str]:
+        return decode_string_list(getattr(obj, "skills", None))
+
+    @staticmethod
+    def _dump_interests(obj: Any) -> list[str]:
+        return decode_string_list(getattr(obj, "interests", None))
+
+
+class UserUpdateSchema(Schema):
+    """Schema for validating user updates."""
+
+    name = fields.String(validate=Length(min=1, max=120))
+    title = fields.String(validate=Length(max=120))
+    company = fields.String(validate=Length(max=120))
+    location = fields.String(validate=Length(max=120))
+    industry = fields.String(validate=Length(max=120))
+    linkedin_url = fields.String(validate=URL(), allow_none=True)
+    experience_years = fields.Integer(validate=Range(min=0, max=100))
+    bio = fields.String(validate=Length(max=2000))
+    timezone = fields.String(validate=Length(max=64))
+    is_active = fields.Boolean()
+    skills = fields.List(
+        fields.String(validate=Length(min=1, max=60)),
+        load_default=None,
+    )
+    interests = fields.List(
+        fields.String(validate=Length(min=1, max=60)),
+        load_default=None,
+    )
+
+    @post_load
+    def _normalize_lists(
+        self,
+        data: dict[str, Any],
+        **_: Any,
+    ) -> dict[str, Any]:
+        for key in ("skills", "interests"):
+            if key in data and data[key] is not None:
+                data[key] = normalize_string_list(data[key])
+        if "linkedin_url" in data and not data["linkedin_url"]:
+            data["linkedin_url"] = None
+        return data
+
+    @pre_load
+    def _coerce_blank(
+        self,
+        data: dict[str, Any],
+        **_: Any,
+    ) -> dict[str, Any]:
+        if isinstance(data, dict) and data.get("linkedin_url", None) == "":
+            data["linkedin_url"] = None
+        return data
+
+    @validates_schema
+    def _ensure_payload(self, data: dict[str, Any], **_: Any) -> None:
+        if not data:
+            raise ValidationError("no fields provided")

--- a/src/services/uploads.py
+++ b/src/services/uploads.py
@@ -1,0 +1,60 @@
+"""Utilities for managing file uploads."""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+from werkzeug.datastructures import FileStorage
+from werkzeug.utils import secure_filename
+
+ALLOWED_EXTENSIONS = {"png", "jpg", "jpeg", "webp"}
+MAX_FILE_SIZE = 5 * 1024 * 1024  # 5 MiB
+
+
+class UploadError(ValueError):
+    """Raised when an uploaded file is invalid."""
+
+
+def save_user_photo(
+    file_storage: FileStorage,
+    *,
+    user_id: int,
+    upload_folder: str,
+    url_prefix: str = "/uploads",
+) -> str:
+    """Persist a user photo to disk and return its public URL."""
+
+    filename = (file_storage.filename or "").strip()
+    if not filename:
+        raise UploadError("missing filename")
+
+    sanitized = secure_filename(filename)
+    if not sanitized:
+        raise UploadError("invalid filename")
+
+    ext = sanitized.rsplit(".", 1)[-1].lower() if "." in sanitized else ""
+    if ext not in ALLOWED_EXTENSIONS:
+        raise UploadError("unsupported file type")
+
+    stream = file_storage.stream
+    if hasattr(stream, "seek") and hasattr(stream, "tell"):
+        current = stream.tell()
+        stream.seek(0, os.SEEK_END)
+        size = stream.tell()
+        stream.seek(current)
+        if size > MAX_FILE_SIZE:
+            raise UploadError("file too large")
+
+    upload_path = Path(upload_folder)
+    upload_path.mkdir(parents=True, exist_ok=True)
+
+    unique_name = f"user-{user_id}-{int(time.time())}.{ext}"
+    destination = upload_path / unique_name
+    file_storage.save(destination)
+
+    prefix = url_prefix.rstrip("/")
+    if prefix:
+        return f"{prefix}/{unique_name}"
+    return f"/{unique_name}"

--- a/src/utils/lists.py
+++ b/src/utils/lists.py
@@ -1,0 +1,50 @@
+"""Helpers for serializing string lists."""
+
+from __future__ import annotations
+
+import json
+from typing import Iterable
+
+
+def normalize_string_list(values: Iterable[str] | None) -> list[str]:
+    """Normalize a collection of strings into a unique, ordered list."""
+
+    normalized: list[str] = []
+    seen: set[str] = set()
+    if not values:
+        return normalized
+    for value in values:
+        if value is None:
+            continue
+        cleaned = value.strip()
+        if not cleaned:
+            continue
+        lowered = cleaned.lower()
+        if lowered in seen:
+            continue
+        normalized.append(lowered)
+        seen.add(lowered)
+    return normalized
+
+
+def encode_string_list(values: Iterable[str] | None) -> str | None:
+    """Serialize a collection of strings as JSON for persistence."""
+
+    normalized = normalize_string_list(values)
+    if not normalized:
+        return None
+    return json.dumps(normalized, separators=(",", ":"))
+
+
+def decode_string_list(raw: str | None) -> list[str]:
+    """Decode a JSON-encoded list of strings."""
+
+    if not raw:
+        return []
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return []
+    if isinstance(data, list):
+        return [str(item) for item in data if isinstance(item, str)]
+    return []

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -18,14 +18,15 @@ def test_health(client):
 def test_users_endpoint(client):
     response = client.get("/users")
     assert response.status_code == 200
-    assert response.get_json() == {"users": []}
+    body = response.get_json()
+    assert body == {"items": [], "page": 1, "per_page": 20, "total": 0}
 
 
 def test_not_found(client):
     response = client.get("/missing")
     assert response.status_code == 404
     payload = response.get_json()
-    assert payload["error"]
+    assert payload["error"]["code"] == 404
 
 
 def test_cors_headers(client):

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -1,0 +1,139 @@
+"""Tests for the user profile endpoints."""
+
+from __future__ import annotations
+
+import io
+import os
+import tempfile
+
+import pytest
+
+from src.db.session import session_scope
+from src.models.user_repository import UserRepository
+
+
+@pytest.fixture
+def seeded_users():
+    with session_scope() as session:
+        repo = UserRepository(session)
+        alice = repo.create_user(
+            email="alice@example.com",
+            name="Alice",
+            industry="Technology",
+            location="Paris",
+            experience_years=5,
+            title="Platform Engineer",
+            skills=["python", "flask"],
+            interests=["networking"],
+        )
+        bob = repo.create_user(
+            email="bob@example.com",
+            name="Bob",
+            industry="Finance",
+            location="London",
+            experience_years=8,
+            skills=["excel", "python"],
+        )
+        carol = repo.create_user(
+            email="carol@example.com",
+            name="Carol",
+            industry="Technology",
+            location="Paris",
+            experience_years=2,
+            skills=["javascript"],
+            bio="Enthusiastic engineer",
+        )
+        yield {"alice": alice, "bob": bob, "carol": carol}
+
+
+def test_list_users_with_filters(client, seeded_users):
+    response = client.get(
+        "/users",
+        query_string={
+            "industry": "Technology",
+            "location": "Paris",
+            "skills": "python",
+            "sort": "experience_years:desc",
+        },
+    )
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["total"] == 1
+    assert payload["items"][0]["email"] == "alice@example.com"
+    assert payload["items"][0]["skills"] == ["python", "flask"]
+
+
+def test_get_user_returns_profile(client, seeded_users):
+    alice_id = seeded_users["alice"].id
+    response = client.get(f"/users/{alice_id}")
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["user"]["name"] == "Alice"
+    assert body["user"]["industry"] == "Technology"
+
+
+def test_update_user(client, seeded_users):
+    alice_id = seeded_users["alice"].id
+    response = client.put(
+        f"/users/{alice_id}",
+        json={
+            "title": "Senior Engineer",
+            "skills": ["Python", "Flask", "SQLAlchemy"],
+            "linkedin_url": "https://linkedin.com/in/alice",
+        },
+    )
+    assert response.status_code == 200
+    updated = response.get_json()["user"]
+    assert updated["title"] == "Senior Engineer"
+    assert "sqlalchemy" in updated["skills"]
+
+    with session_scope() as session:
+        repo = UserRepository(session)
+        stored = repo.get(alice_id)
+        assert stored.title == "Senior Engineer"
+        assert stored.linkedin_url == "https://linkedin.com/in/alice"
+
+
+def test_delete_user(client, seeded_users):
+    bob_id = seeded_users["bob"].id
+    response = client.delete(f"/users/{bob_id}")
+    assert response.status_code == 204
+
+    with session_scope() as session:
+        repo = UserRepository(session)
+        assert repo.get(bob_id) is None
+
+
+def test_upload_photo(client, seeded_users, tmp_path):
+    user_id = seeded_users["carol"].id
+    temp_dir = tempfile.mkdtemp(dir=tmp_path)
+    client.application.config["UPLOAD_FOLDER"] = temp_dir
+    client.application.config["UPLOAD_URL_PREFIX"] = "/media"
+
+    image_data = io.BytesIO(b"\x89PNG\r\n\x1a\n" + b"0" * 16)
+    image_data.name = "avatar.png"
+
+    response = client.post(
+        f"/users/{user_id}/photo",
+        data={"photo": (image_data, "avatar.png")},
+        content_type="multipart/form-data",
+    )
+    assert response.status_code == 201
+    payload = response.get_json()
+    assert payload["user_id"] == user_id
+    assert payload["photo_url"].startswith("/media/")
+
+    stored_file = os.path.join(
+        temp_dir,
+        os.path.basename(payload["photo_url"]),
+    )
+    assert os.path.exists(stored_file)
+
+
+def test_search_users(client, seeded_users):
+    response = client.get("/users/search", query_string={"q": "engineer"})
+    assert response.status_code == 200
+    data = response.get_json()
+    emails = {item["email"] for item in data["items"]}
+    assert "carol@example.com" in emails
+    assert "alice@example.com" in emails


### PR DESCRIPTION
## Summary
- add CODEOWNERS and document upload configuration for the service
- extend the user persistence layer with additional profile fields, migrations, and helpers
- expose REST endpoints for user listing, detail, updates, deletion, search, and photo uploads with new tests

## Testing
- flake8 src tests
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d97d48e7d48332aad0655bd9d79109